### PR TITLE
Fix Wrong Method Name generation with invalid characters

### DIFF
--- a/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration/ClientGeneratorBase.cs
@@ -162,7 +162,7 @@ namespace NSwag.CodeGeneration
                     var operationName = BaseSettings.OperationNameGenerator.GetOperationName(document, path, httpMethod, operation);
 
                     // Strip any character that is not a word character or a period
-                    operationName = Regex.Replace(operationName, @"[^\w\.]", "", RegexOptions.None);
+                    operationName = Regex.Replace(operationName, @"[^\w\.-]", "", RegexOptions.None);
 
                     if (operationName.Contains("."))
                     {


### PR DESCRIPTION
when there is a route with parameters inside like this:

GET /api/details/data/{code}

the client is generated with wrong signatures:

System.Threading.Tasks.Task Conto{code}Async(string code);
System.Threading.Tasks.Task Conto{code}Async(string code, System.Threading.CancellationToken cancellationToken);

This fix will remove any invalid character from the signature